### PR TITLE
m216240 - Update site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@
 
 * [Policy](policy.md)
 * [Calendar](calendar.md)
-* [Units](units/README.md)
-* [HW](hw/README.md)
-* [Labs](labs/README.md)
+* [Units](units/)
+* [HW](hw/)
+* [Labs](lab/)
+* [Projects](/proj/)
 * [Resources](resources.md)
     
     

--- a/hw/README.md
+++ b/hw/README.md
@@ -1,0 +1,12 @@
+# HOMEWORK
+
+* [HW 0: Install QtSPim](/hw/hw00.md)
+* [HW 1: Due 16 Jan 2019](/hw/hw01.pdf)
+* [HW 2: Due 23 Jan 2019](/hw/hw02.pdf)
+* [HW 3: Due 1 Feb 2019](/hw/hw03.pdf)
+* [HW 4: Due 13 Feb 2019](/hw/hw04.pdf)
+* [HW 5: Due 23 Feb 2019](/hw/hw05.pdf)
+* [HW 6: Due 25 Mar 2019](/hw/hw06.pdf)
+
+### Resources
+* [HW reading sheet](/rsc/reading_sheet.pdf)

--- a/lab/README.md
+++ b/lab/README.md
@@ -1,0 +1,9 @@
+# LABS
+
+* [Lab 1: SPIM Lab](/lab/lab01.md)
+* [Lab 2: LogiSim Lab](/lab/lab02.md)
+
+### LAB Resources
+
+* [Lab coversheet](/rsc/lab_coversheet.pdf)
+* [Spim resources](/rsc/spim)

--- a/units/README.md
+++ b/units/README.md
@@ -1,4 +1,14 @@
 # Units
 
-* [Introduction to Computer Architecture](/units//unit_01.md)
+* [Introduction to Computer Architecture](/units/unit_01.md)
+    * Chapter 1
 * [Assembly Programming Basics](/units/unit_02.md)
+    * Chapter 2.1-2.3, 2.5-2.10 and 2.12
+* [Digital Logic](/units/unit_03.md)
+    * Chapter B.1-B.3, B.5
+* [Arithmetic Logic and Data](/units/unit_04.md)
+    * Chapter B.6-B.10, B.12
+* [Arithmetic Logic and Data Representation](/units/unit_05.md)
+    * Chapter  2.4, 3.1-3.4, (skim 3.5), pgs. 259-262
+* [Performance](/units/unit_06.md)
+    * Chapter 1.6, 1.9-1.11


### PR DESCRIPTION
This commit updated the home README links so that they all point
somewhere. It updates the README files for hw, labs, and units
so that they accurately represent the current directories. The
home README links now point to the directories instead of the .md
files, because this will allow students to see the contents of the
directory, but still see the README files.